### PR TITLE
Be more lenient with trim()

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -14,10 +14,13 @@ var Backgrid = root.Backgrid = {
 };
 
 function trim(s) {
-  if (String.prototype.trim) {
+  if (s === null || s === void(0)) {
+    return '';
+  }
+  else if (String.prototype.trim) {
     return String.prototype.trim.call(s, s);
   }
-
+  
   return s.replace(/^\s+|\s+$/g, "");
 }
 


### PR DESCRIPTION
Allowing for null and undefined values passed to trim() to return empty string.

I'm not sure if you would rather deal with this in the functions calling trim() but this will at least allow some flexibility handling attributes that may be null or contain a string.
