### PR TITLE
ellipsis not ellipses

### DIFF
--- a/src/backgrid.css
+++ b/src/backgrid.css
@@ -35,7 +35,7 @@
   overflow: hidden;
   line-height: 20px;
   text-align: left;
-  text-overflow: ellipses;
+  text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
   border: 1px solid #DDD;


### PR DESCRIPTION
In backgrid.css there is a typo

``` css
  text-overflow: ellipses;
```

It's `text-overflow: ellipsis;` not `text-overflow: ellipses;`
