### PR TITLE
Fix jQuery reference in closure invokation "$" -> "jQuery"

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2164,4 +2164,4 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
   }
 
 });
-}(this, $, _, Backbone));
+}(this, jQuery, _, Backbone));


### PR DESCRIPTION
I had an issue when trying to use backgrid where it assumes that jQuery is $.  For unfortunate reasons the codebase I'm working on has a ton of legacy javascript that makes use of Prototype.JS.  This change rectifies issues that cause backgrid to completely fail to function given this type of restriction.
