### PR TITLE
Allow user to specify link display text by subclassing `UriCell`

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -718,14 +718,25 @@ var UriCell = Backgrid.UriCell = Cell.extend({
     }
   },
 
+  // Override this to change the link display text (the text contents
+  // of the `<a>` element). The function has access to the current row
+  // via `this.model`.
+  displayText: function () {
+      return undefined;
+  },
+
   render: function () {
     this.$el.empty();
     var formattedValue = this.formatter.fromRaw(this.model.get(this.column.get("name")));
+    var displayText = this.displayText();
+    if (_.isNull(displayText) || _.isUndefined(displayText)) {
+        displayText = formattedValue;
+    }
     this.$el.append($("<a>", {
       href: formattedValue,
       title: formattedValue,
       target: "_blank"
-    }).text(formattedValue));
+    }).text(displayText));
     return this;
   }
 

--- a/test/cell.js
+++ b/test/cell.js
@@ -371,6 +371,57 @@ describe("A UriCell", function () {
 
 });
 
+describe("A UriCell with custom display text", function () {
+
+  var model;
+  var column;
+  var cell;
+
+  UriCellWithDisplayText = Backgrid.UriCell.extend({
+      displayText: function() {
+          return this.model.get('displayText');
+      }
+  });
+
+  beforeEach(function () {
+    model = new Backbone.Model({
+      url: "http://www.example.com",
+      displayText: "example display text with a \u0a85 Gujarati character"
+    });
+
+    column = {
+      name: "url",
+      cell: UriCellWithDisplayText
+    };
+
+    cell = new UriCellWithDisplayText({
+      model: model,
+      column: column
+    });
+  });
+
+  it("applies a uri-cell class to the cell", function () {
+    cell.render();
+    expect(cell.$el.hasClass("uri-cell")).toBe(true);
+  });
+
+  it("renders the model value in an anchor", function () {
+    cell.render();
+    expect(cell.$el.find("a").attr("href")).toBe("http://www.example.com");
+    expect(cell.$el.find("a").text()).toBe("example display text with a \u0a85 Gujarati character");
+  });
+
+  it(".formatter.fromRaw() accepts any string without conversion", function () {
+    expect(cell.formatter.fromRaw("whatever")).toBe("whatever");
+  });
+
+  it(".formatter.toRaw() URI encode the values", function () {
+    expect(cell.formatter.toRaw()).toBeUndefined();
+    expect(cell.formatter.toRaw(" ")).toBe("%20");
+  });
+
+});
+
 describe("An EmailCell", function () {
 
   var model;


### PR DESCRIPTION
See wyuenho/backgrid#41

This PR allows users to control the display text of a link formatted by `UriCell` by overriding a function `displayText`. The existing solution is to write a custom cell class, which requires duplication of logic in the render method; with this PR the operation is more straightforward and does not duplicate any logic in the render method.

The PR includes one new test:

![image](https://f.cloud.github.com/assets/52205/306100/2cc2a186-966e-11e2-85f7-20cc14fd2903.png)
