### PR TITLE
Fix regression on BooleanCell navigation which does not inherit enterEdi...

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -639,7 +639,7 @@ var BooleanCell = Backgrid.BooleanCell = Cell.extend({
   },
 
   /** 
-    exitEditMode neds to be called with the right arguments 
+    Not much to do here, just stop being an editor when blurring
   */
   triggerExitEditMode: function(e) {
     this.$el.removeClass("editor");


### PR DESCRIPTION
...tModt() from Cell

BooleanCell overrides Cell.enterEditMode() which means we need a custom way to deal with blurs/exits/keydowns and so on.
