### PR TITLE
Grid.unselectSelectedModels

### DIFF
--- a/src/extensions/select-all/backgrid-select-all.js
+++ b/src/extensions/select-all/backgrid-select-all.js
@@ -148,6 +148,14 @@
 
   });
 
+  var getSelectAllHeaderCell = function (grid) {
+    var headerCells = grid.header.row.cells;
+    for (var i = 0, l = headerCells.length; i < l; i++) {
+      var headerCell = headerCells[i];
+      if (headerCell instanceof SelectAllHeaderCell) return headerCell;
+    }
+  };
+
   /**
      Convenient method to retrieve a list of selected models. This method only
      exists when the `SelectAll` extension has been included.
@@ -156,16 +164,7 @@
      @return {Array.<Backbone.Model>}
    */
   Backgrid.Grid.prototype.getSelectedModels = function () {
-    var selectAllHeaderCell;
-    var headerCells = this.header.row.cells;
-    for (var i = 0, l = headerCells.length; i < l; i++) {
-      var headerCell = headerCells[i];
-      if (headerCell instanceof SelectAllHeaderCell) {
-        selectAllHeaderCell = headerCell;
-        break;
-      }
-    }
-
+    var selectAllHeaderCell = getSelectAllHeaderCell(this);
     var result = [];
     if (selectAllHeaderCell) {
       for (var modelId in selectAllHeaderCell.selectedModels) {
@@ -174,6 +173,23 @@
     }
 
     return result;
+  };
+
+  /**
+     Un-select all selected models. This method only
+     exists when the `SelectAll` extension has been included.
+
+     @member Backgrid.Grid
+     @return {Array.<Backbone.Model>}
+   */
+  Backgrid.Grid.prototype.unselectSelectedModels = function () {
+    var selectAllHeaderCell = getSelectAllHeaderCell(this);
+    if (selectAllHeaderCell) {
+      selectAllHeaderCell.$(":checkbox").prop("checked", false);
+      this.collection.each(function (model) {
+        model.trigger("backgrid:select", model, false);
+      });
+    }
   };
 
 }(window, jQuery, _, Backbone, Backgrid));

--- a/src/extensions/select-all/backgrid-select-all.js
+++ b/src/extensions/select-all/backgrid-select-all.js
@@ -180,7 +180,6 @@
      exists when the `SelectAll` extension has been included.
 
      @member Backgrid.Grid
-     @return {Array.<Backbone.Model>}
    */
   Backgrid.Grid.prototype.unselectSelectedModels = function () {
     var selectAllHeaderCell = getSelectAllHeaderCell(this);

--- a/test/extensions/select-all.js
+++ b/test/extensions/select-all.js
@@ -149,3 +149,42 @@ describe("Grid#getSelectedModels", function () {
   });
 
 });
+
+describe("Grid#unselectSelectedModels", function () {
+
+  it("will be attached to Backgrid.Grid's prototype", function () {
+    expect(typeof Backgrid.Grid.prototype.unselectSelectedModels).toBe("function");
+  });
+
+  it("will unselect all selected models", function () {
+    var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
+
+    var grid = new Backgrid.Grid({
+      collection: collection,
+      columns: [{
+        name: "",
+        cell: "select-row",
+        headerCell: "select-all"
+      }, {
+        name: "id",
+        cell: "integer"
+      }]
+    });
+
+    grid.render();
+
+    collection.each(function (model) {
+      model.trigger("backgrid:selected", model, true);
+    });
+
+    var selectedModels = grid.getSelectedModels();
+    expect(selectedModels.length).toBe(2);
+    expect(selectedModels[0].id).toBe(1);
+    expect(selectedModels[1].id).toBe(2);
+
+    grid.unselectSelectedModels();
+    var selectedModels = grid.getSelectedModels();
+    expect(selectedModels.length).toBe(0);
+  });
+
+});


### PR DESCRIPTION
Uses the select-all checkbox to deselect all selected models. Factor out separate function `getSelectAllHeaderCell`.

I found that I needed a function to unselect all currently selected models. In my case it was after the user performs an action on some selected rows.
##### Testing

One test is added. The same set of tests fail on this branch as fail on wyuenho:master.

![image](https://f.cloud.github.com/assets/52205/345083/16380bb8-9e16-11e2-9b97-da5515128aee.png)

The added test is not DRY. I could incorporate it into the test for `getSelectedModels` if you prefer.
