### PR TITLE
Only style as striped table when .backgrid-striped class is applied

### DIFF
--- a/src/backgrid.css
+++ b/src/backgrid.css
@@ -54,8 +54,8 @@
   vertical-align: bottom;
 }
 
-.backgrid tbody tr:nth-child(odd) td,
-.backgrid tbody tr:nth-child(odd) th {
+.backgrid.backgrid-striped tbody tr:nth-child(odd) td,
+.backgrid.backgrid-striped tbody tr:nth-child(odd) th {
   background-color: #f9f9f9;
 }
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -59,7 +59,7 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
   tagName: "table",
 
   /** @property */
-  className: "backgrid",
+  className: "backgrid backgrid-striped",
 
   /** @property */
   header: Header,


### PR DESCRIPTION
The `.backgrid` class applies table striping styling which is incompatible with [bootstrap table styling](http://twitter.github.io/bootstrap/base-css.html#tables). Would it make sense to pull the striping style out into a separate css class `.backgrid-striped` as is done in this PR?

E.g. in my case, I wanted to apply the bootstrap row class `.info` which would change the background color; however this does not change the background color of odd rows due to the backgrid css. With the change in this PR however, my application can remove the default `.backgrid-striped` class and things seem to work as hoped (I believe using a space-separated string of class names for backbone `className` works as expected.)
