### PR TITLE
Fix problem that override options for footer, and others

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2120,15 +2120,20 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
     }
     this.columns = options.columns;
 
+    var requiredOptions = {
+      columns: options.columns,
+      collection: options.collection
+    }
+
     this.header = options.header || this.header;
-    this.header = new this.header(options);
+    this.header = new this.header(requiredOptions);
 
     this.body = options.body || this.body;
-    this.body = new this.body(options);
+    this.body = new this.body(requiredOptions);
 
     this.footer = options.footer || this.footer;
     if (this.footer) {
-      this.footer = new this.footer(options);
+      this.footer = new this.footer(requiredOptions);
     }
 
     this.listenTo(this.columns, "reset", function () {


### PR DESCRIPTION
Right now if you apply a className like below:

``` javascript
var Footer = Backgrid.Footer.extend({
  className: "FooterClass",
  tagName: "tfoot",
});

var grid = new Backgrid.Grid({
  className: 'MyTableClass',
  columns: columns,
  collection: collection,
  footer: Footer
});
```

It will create this HTML

``` html
<table class="MyTableClass">
  <thead class="MyTableClass">
  <tfoot class"MyTableClass">
  <tbody class="MyTableClass">
```

This change pass only the required columns and collection options to Footer, Body and Header, so other options like className won't be overridden.
