### PR TITLE
exitEditMode getting called twice on move command

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -242,6 +242,8 @@ var Body = Backgrid.Body = Backbone.View.extend({
     var i = this.collection.indexOf(model);
     var j = this.columns.indexOf(column);
 
+    this.rows[i].cells[j].exitEditMode();
+
     if (command.moveUp() || command.moveDown() || command.moveLeft() ||
         command.moveRight() || command.save()) {
       var l = this.columns.length;
@@ -266,7 +268,5 @@ var Body = Backgrid.Body = Backbone.View.extend({
         }
       }
     }
-
-    this.rows[i].cells[j].exitEditMode();
   }
 });


### PR DESCRIPTION
When using move commands (tab, arrows, etc.), the `exitEditMode` method of the editor is being called twice. You can see the error [here](http://jsfiddle.net/p2n9P/3/) by simply using a move command.

The reason is, [here](https://github.com/wyuenho/backgrid/blob/master/src/body.js#L245), when you call `enterEditMode`, the `postRender` method of the new cell editor calls `focus` on the new editor element, which results in a `blur` event on the old editor. The `saveOrCancel` method is then called again on the old editor, and then triggers the `backgrid:edited` event a second time.

You can resolve this simply by moving [this](https://github.com/wyuenho/backgrid/blob/master/src/body.js#L270) line before the `if` block, to make sure that the old editor is actually removed before entering in the new editor.
