### PR TITLE
Ecmascript 3 denotes 'char' as "future reserved word"

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -99,7 +99,7 @@ _.extend(Backgrid, Backbone.Events);
 var Command = Backgrid.Command = function (evt) {
   _.extend(this, {
     altKey: !!evt.altKey,
-    'char': evt['char'],
+    "char": evt["char"],
     charCode: evt.charCode,
     ctrlKey: !!evt.ctrlKey,
     key: evt.key,


### PR DESCRIPTION
Yuicompressor fails to compress this file because 'char' is a "future reserved word". The fix contains equivalent functionality avoiding the bare 'char' word.

Ecmascript 5 dropped this reserved word, but supporting Ecmascript 3 is just a one line change.

See Ecmascript 3 spec, section 7.5.3: http://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%203rd%20edition,%20December%201999.pdf
