### PR TITLE
fix remove handler to also delete references to existing models

### DIFF
--- a/lib/extensions/select-all/backgrid-select-all.js
+++ b/lib/extensions/select-all/backgrid-select-all.js
@@ -155,7 +155,7 @@
       });
 
       this.listenTo(collection, "remove", function (model) {
-        delete selectedModels[model.cid];
+        delete selectedModels[model.id || model.cid];
       });
 
       this.listenTo(collection, "backgrid:refresh", function () {

--- a/src/extensions/select-all/backgrid-select-all.js
+++ b/src/extensions/select-all/backgrid-select-all.js
@@ -155,7 +155,7 @@
       });
 
       this.listenTo(collection, "remove", function (model) {
-        delete selectedModels[model.cid];
+        delete selectedModels[model.id || model.cid];
       });
 
       this.listenTo(collection, "backgrid:refresh", function () {


### PR DESCRIPTION
The backgrid-select-all extension was removing references to unsaved models but not saved models. This fixes the issue by checking for model.id instead of just model.cid:

```
  this.listenTo(collection, "remove", function (model) {
    delete selectedModels[model.id || model.cid];
  });
```
