### PR TITLE
Add a `grid` option to Body and Row for bubbling events up to a Grid

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -40,11 +40,14 @@ var Body = Backgrid.Body = Backbone.View.extend({
       this.columns = new Columns(this.columns);
     }
 
+    this.grid = options.grid;
+
     this.row = options.row || Row;
     this.rows = this.collection.map(function (model) {
       var row = new this.row({
         columns: this.columns,
-        model: model
+        model: model,
+        grid: this.grid
       });
 
       return row;
@@ -107,7 +110,8 @@ var Body = Backgrid.Body = Backbone.View.extend({
 
     var row = new this.row({
       columns: this.columns,
-      model: model
+      model: model,
+      grid: this.grid
     });
 
     var index = collection.indexOf(model);

--- a/src/grid.js
+++ b/src/grid.js
@@ -93,6 +93,7 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
 
     var passedThruOptions = _.omit(options, ["el", "id", "attributes",
                                              "className", "tagName", "events"]);
+    _.extend(passedThruOptions, {grid: this});
 
     this.header = options.header || this.header;
     this.header = new this.header(passedThruOptions);


### PR DESCRIPTION
This `grid` option allows custom Row classes to bubble events up to
the containing Grid instance. Because Rows are handled as a simple
array (vs. as a collection), having a Row trigger events on it's
containing Grid would involve lots of overriding methods and event
bookkeeping. 

Passing a reference to the containing Grid all the way
down to the Row allows each Row to determine what event should
"bubble" up to the container. For example, now you can patch the Row
to "bubble" all events (namespaced) up to the containing Grid with
just a few lines:

``` javascript
var rowInit = Backgrid.Row.prototype.initialize
Backgrid.Row.prototype.initialize = function(options) {
  this.grid = options.grid;
  rowInit.apply(this, arguments);
  this.listenTo(this, 'all', function(eventName) {
    this.grid.trigger.apply(this.grid, ['row:' + eventName].concat(arguments.slice(1)));
  });
}
```
