### PR TITLE
Fix undefined root error.

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -39,6 +39,8 @@ function lpad(str, length, padstr) {
   return padding + str;
 }
 
+var root = this;
+
 var Backgrid = root.Backgrid = {
 
   VERSION: "0.3.0",


### PR DESCRIPTION
I'm getting this error on backbone 1.0 and backgrid's master:

![screen shot 2013-07-10 at 3 29 55 pm](https://f.cloud.github.com/assets/51424/774869/f9d446cc-e964-11e2-8eb6-66cb4fe543b6.png)

This PR sets the `root` variable to the `window` object.
