### PR TITLE
header cell to render a span instead of an anchor when not sortable

### DIFF
--- a/src/backgrid.css
+++ b/src/backgrid.css
@@ -48,7 +48,6 @@
 
 .backgrid th {
   font-weight: bold;
-  cursor: pointer;
 }
 
 .backgrid th a {

--- a/src/header.js
+++ b/src/header.js
@@ -127,9 +127,14 @@ var HeaderCell = Backgrid.HeaderCell = Backbone.View.extend({
     this.$el.empty();
     var column = this.column;
     var sortable = Backgrid.callByNeed(column.sortable(), column, this.collection);
-    var $label = $(sortable ? "<a>" : "<span>").text(column.get("label"));
-    if (sortable) $label.append("<b class='sort-caret'></b>");
-    this.$el.append($label);
+    var label;
+    if(sortable){
+      label = $("<a>").text(column.get("label")).append("<b class='sort-caret'></b>");
+    } else {
+      label = column.get("label");
+    }
+
+    this.$el.append(label);
     this.$el.addClass(column.get("name"));
     this.delegateEvents();
     this.direction(column.get("direction"));

--- a/test/header.js
+++ b/test/header.js
@@ -23,7 +23,7 @@ describe("A HeaderCell", function () {
     cell.render();
   });
 
-  it("renders a table header cell with an anchor (sortable) or span (non-sortable) wrapping the label text and an optional sort caret", function () {
+  it("renders a table header cell with the label text and an optional anchor with sort-caret", function () {
     expect(cell.el.tagName).toBe("TH");
     expect(cell.$el.find("a").text()).toBe("id");
     expect(cell.$el.find(".sort-caret").length).toBe(1);
@@ -31,7 +31,7 @@ describe("A HeaderCell", function () {
     cell.column.set("sortable", false);
     cell.render();
     expect(cell.el.tagName).toBe("TH");
-    expect(cell.$el.find("span").text()).toBe("id");
+    expect(cell.$el.text()).toBe("id");
     expect(cell.$el.find(".sort-caret").length).toBe(0);
   });
 


### PR DESCRIPTION
If a column has `sortable` set to false, then it'd be nice if the headerCell didn't render an anchor tag.
The anchor tag often has default styling, looking like a link, which could mislead the user into thinking it is a clickable/sortable header. 

Attached is a pull request that uses a `span` tag instead of an `a` when `sortable: false`.  
