### PR TITLE
Add the possibility to click the whole header cell to sort the column

### DIFF
--- a/src/backgrid.css
+++ b/src/backgrid.css
@@ -60,6 +60,10 @@
   background-color: #f9f9f9;
 }
 
+.backgrid thead th a {
+  display: block;
+}
+
 .backgrid.backgrid-striped tbody tr:nth-child(even) {
   background-color: #f9f9f9;
 }


### PR DESCRIPTION
Instead of having to click on the header cell text to sort the column, 
add the possibility to click the whole cell.
