### PR TITLE
Add support for using direct functions on column definitions for editable, renderable & sortable

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -718,7 +718,7 @@ var BooleanCell = Backgrid.BooleanCell = Cell.extend({
     this.$el.append($("<input>", {
       tabIndex: -1,
       type: "checkbox",
-      checked: !!this.formatter.fromRaw(model.get(column.get("name")), model),
+      checked: this.formatter.fromRaw(model.get(column.get("name")), model),
       disabled: !editable
     }));
     this.delegateEvents();


### PR DESCRIPTION
Row(model)-wise support for editable, renderable & sortable.
Analogous with sortValue.
example:
    {
      "name":"amount_order",
      "editable":function(model) {
        return model.get('status') < 2
      },
      "cell":"integer",
      "label":"Tilaus"
    }
