### PR TITLE
Typo in PercentFormatter.prototype

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -160,7 +160,7 @@ PercentFormatter.prototype = new Backgrid.NumberFormatter(),
 
 _.extend(PercentFormatter.prototype, {
 
-  defaults: _.extend({}, NumberFormatter.prototype.default, {
+  defaults: _.extend({}, NumberFormatter.prototype.defaults, {
     multiplier: 1,
     symbol: "%"
   }),


### PR DESCRIPTION
NumberFormatter.prototype.default -> defaults

Guessing this was a typo. It threw an error in my browser.
