### PR TITLE
Add support for AMD

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,10 @@ module.exports = function (grunt) {
             '                             require("underscore"),\n' +
             '                             require("backbone"));\n' +
             '  }\n' +
+            '  // AMD\n' +
+            '  else if (typeof define == "function" && define.amd) {\n' +
+            '   define(["exports", "underscore", "backbone"], factory);\n' +
+            '  }\n' +
             '  // Browser\n' +
             '  else factory(this, this._, this.Backbone);\n' +
             '}(function (root, _, Backbone) {\n\n  "use strict";\n\n',


### PR DESCRIPTION
At current moment it is possible to load Backgrid with requirejs via shims, but only if nonConflict is not used for underscore and Backbone dependencies. In other case you cannot reference window.Backbone and window._, because they are undefined.
