### PR TITLE
Add ability to extend Grid with default columns.

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2745,6 +2745,9 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
   /** @property */
   footer: null,
 
+  /** @property */
+  columns: [],
+
   /**
      Initializes a Grid instance.
 
@@ -2757,6 +2760,10 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
      @param {Backgrid.Footer} [options.footer=Backgrid.Footer] An optional Footer class.
    */
   initialize: function (options) {
+    
+    // Set Columns, either passed by options or columns property.
+    options.columns = options.columns || this.columns;
+
     // Convert the list of column objects here first so the subviews don't have
     // to.
     if (!(options.columns instanceof Backbone.Collection)) {

--- a/src/grid.js
+++ b/src/grid.js
@@ -70,6 +70,9 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
   /** @property */
   footer: null,
 
+  /** @property */
+  columns: [],
+
   /**
      Initializes a Grid instance.
 
@@ -82,6 +85,10 @@ var Grid = Backgrid.Grid = Backbone.View.extend({
      @param {Backgrid.Footer} [options.footer=Backgrid.Footer] An optional Footer class.
    */
   initialize: function (options) {
+    
+    // Set Columns, either passed by options or columns property.
+    options.columns = options.columns || this.columns;
+
     // Convert the list of column objects here first so the subviews don't have
     // to.
     if (!(options.columns instanceof Backbone.Collection)) {

--- a/test/grid.js
+++ b/test/grid.js
@@ -14,6 +14,8 @@ describe("A Grid", function () {
 
   var books;
   var grid;
+  var extendedGrid;
+
   beforeEach(function () {
     books = new Books([{
       id: 1,
@@ -34,6 +36,20 @@ describe("A Grid", function () {
       collection: books,
       footer: Backgrid.Footer
     });
+
+    extendedGrid = Backgrid.Grid.extend({
+      columns: [
+        {
+          name: 'title',
+          cell: 'string'
+        },
+        {
+          name: 'id',
+          cell: 'integer'
+        }
+      ]
+    });
+
   });
 
   it("renders a table with a body, optional header, and an optional footer section", function () {
@@ -138,6 +154,26 @@ describe("A Grid", function () {
     expect($(tbody).find("tr:nth-child(2) > td.integer-cell.editable.sortable.renderable").text()).toBe("2");
     expect($(tbody).find("tr:nth-child(3) > td.integer-cell.editable.sortable.renderable").length).toBe(1);
     expect($(tbody).find("tr:nth-child(3) > td.integer-cell.editable.sortable.renderable").text()).toBe("3");
+  });
+
+  it("will intantiate with extended columns", function(){
+    
+    var theGrid = new extendedGrid({ collection: books });
+
+    expect(theGrid.columns.length).toBe(2);
+
+  });
+
+  it('extended grid columns will reset', function(){
+    var theGrid = new extendedGrid({collection: books});
+    theGrid.columns.reset([
+      {
+        name: 'id',
+        cell: 'integer'
+      }
+    ]);
+
+    expect(theGrid.columns.length).toBe(1);
   });
 
 });


### PR DESCRIPTION
Add the ability to extend Backgrid.Grid with base columns. Might be particularly useful in scenarios where Grids will always have a number of columns to start with, keeping things a bit more 'dry'. 
