### PR TITLE
Fix Header not respecting headerCell option

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -190,6 +190,7 @@ var Header = Backgrid.Header = Backbone.View.extend({
      @param {Object} options
      @param {Backbone.Collection.<Backgrid.Column>|Array.<Backgrid.Column>|Array.<Object>} options.columns Column metadata.
      @param {Backbone.Model} options.model The model instance to render.
+     @param {Backgrid.HeaderCell} [options.headerCell] An optional HeaderCell to override the default.
 
      @throws {TypeError} If options.columns or options.model is undefined.
    */
@@ -201,7 +202,8 @@ var Header = Backgrid.Header = Backbone.View.extend({
 
     this.row = new Backgrid.HeaderRow({
       columns: this.columns,
-      collection: this.collection
+      collection: this.collection,
+      headerCell: options.headerCell
     });
   },
 


### PR DESCRIPTION
When `Backgrid.Header` is making a new `Backgrid.HeaderRow`, it doesn't pass the `headerCell` option through.
