### PR TITLE
Toggle editable, sortable and renderable classes on each render

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -880,6 +880,11 @@ var Cell = Backgrid.Cell = Backbone.View.extend({
     this.$el.empty();
     var model = this.model;
     this.$el.text(this.formatter.fromRaw(model.get(this.column.get("name")), model));
+
+    this.$el.toggleClass("editable", Backgrid.callByNeed(this.column.editable(), this.column, this.model));
+    this.$el.toggleClass("sortable", Backgrid.callByNeed(this.column.sortable(), this.column, this.model));
+    this.$el.toggleClass("renderable", Backgrid.callByNeed(this.column.renderable(), this.column, this.model));
+
     this.delegateEvents();
     return this;
   },

--- a/src/cell.js
+++ b/src/cell.js
@@ -261,6 +261,11 @@ var Cell = Backgrid.Cell = Backbone.View.extend({
     this.$el.empty();
     var model = this.model;
     this.$el.text(this.formatter.fromRaw(model.get(this.column.get("name")), model));
+
+    this.$el.toggleClass("editable", Backgrid.callByNeed(this.column.editable(), this.column, this.model));
+    this.$el.toggleClass("sortable", Backgrid.callByNeed(this.column.sortable(), this.column, this.model));
+    this.$el.toggleClass("renderable", Backgrid.callByNeed(this.column.renderable(), this.column, this.model));
+
     this.delegateEvents();
     return this;
   },


### PR DESCRIPTION
Backgrid supports specifying a function to dynamically calculate editable, sortable and renderable state of a cell. However, the way Backgrid.Cell is initialized and rendered does not allow to update associated css classes in case of field value change.

Let's say, if initialt column.editable(model) returns true, then value of the model field is changed, column.editable(model) returns false, Backgrid.Cell received change:column_name event and calls this.render(). At this moment, we have non-editable cell with ".editable" css class.

This PR tries to update editable, sortable and renderable css class right after cell is re-rendered
