### PR TITLE
Render empty row if all existing rows are removed

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,3 +25,4 @@ John Moses <moses.john.r@gmail.com>
 Ian Lim <mallim.ink@gmail.com>
 David Burrows <david@imergent.com>
 Anthony Wu <wu@learnsprout.com>
+Marc Neuwirth <marc.neuwirth@gmail.com>

--- a/src/body.js
+++ b/src/body.js
@@ -67,6 +67,7 @@ var Body = Backgrid.Body = Backbone.View.extend({
         emptyText: this.emptyText,
         columns: this.columns
       }));
+      return true;
     }
   },
 
@@ -154,7 +155,9 @@ var Body = Backgrid.Body = Backbone.View.extend({
     // removeRow() is called directly
     if (!options) {
       this.collection.remove(model, (options = collection));
-      this._unshiftEmptyRowMayBe();
+      if (this._unshiftEmptyRowMayBe()) {
+        this.render();
+      }
       return;
     }
 
@@ -163,7 +166,9 @@ var Body = Backgrid.Body = Backbone.View.extend({
     }
 
     this.rows.splice(options.index, 1);
-    this._unshiftEmptyRowMayBe();
+    if (this._unshiftEmptyRowMayBe()) {
+      this.render();
+    }
 
     return this;
   },

--- a/test/body.js
+++ b/test/body.js
@@ -247,6 +247,29 @@ describe("A Body", function () {
     expect(body.$el.find("tr.empty").length).toBe(0);
   });
 
+  it("will show the empty row if all rows are removed from the collection", function () {
+    col.reset({id: 4});
+    body = new Backgrid.Body({
+      emptyText: " ",
+      columns: [{
+        name: "id",
+        cell: "integer"
+      }],
+      collection: col
+    });
+    body.render();
+    expect(body.$el.find("tr.empty").length).toBe(0);
+
+    col.remove(col.at(0));
+    expect(body.$el.find("tr.empty").length).toBe(1);
+
+    body.insertRow({id: 5});
+    expect(body.$el.find("tr.empty").length).toBe(0);
+
+    body.removeRow(col.at(0));
+    expect(body.$el.find("tr.empty").length).toBe(1);
+  });
+
   it("#sort will throw a RangeError is direction is not ascending, descending or null", function () {
     body = new Backgrid.Body({
       collection: col,


### PR DESCRIPTION
The empty row renders fine if initializing a table with an empty collection,
but if models/rows are removed the empty row is never rendered. This will call
`this.render` if the empty row is unshifted into `this.rows`.
