### PR TITLE
Applying fix for issue Double sort indicators #453.

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2541,8 +2541,9 @@ var Body = Backgrid.Body = Backbone.View.extend({
       else {
         // Trigger a sort event on the collection, which currently does not
         // trigger this event for server-side collections.
-        collection.trigger("sort");
         collection.fetch({reset: true, success: function () {
+          //collection.trigger("sort");
+          //column.set("direction", direction);
           collection.trigger("backgrid:sorted", column, direction, collection);
         }});
       }

--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2538,9 +2538,14 @@ var Body = Backgrid.Body = Backbone.View.extend({
         collection.fullCollection.sort();
         collection.trigger("backgrid:sorted", column, direction, collection);
       }
-      else collection.fetch({reset: true, success: function () {
-        collection.trigger("backgrid:sorted", column, direction, collection);
-      }});
+      else {
+        // Trigger a sort event on the collection, which currently does not
+        // trigger this event for server-side collections.
+        collection.trigger("sort");
+        collection.fetch({reset: true, success: function () {
+          collection.trigger("backgrid:sorted", column, direction, collection);
+        }});
+      }
     }
     else {
       collection.comparator = comparator;

--- a/src/body.js
+++ b/src/body.js
@@ -287,9 +287,14 @@ var Body = Backgrid.Body = Backbone.View.extend({
         collection.fullCollection.sort();
         collection.trigger("backgrid:sorted", column, direction, collection);
       }
-      else collection.fetch({reset: true, success: function () {
-        collection.trigger("backgrid:sorted", column, direction, collection);
-      }});
+      else {
+        // Trigger a sort event on the collection, which currently does not
+        // trigger this event for server-side collections.
+        collection.trigger("sort");
+        collection.fetch({reset: true, success: function () {
+          collection.trigger("backgrid:sorted", column, direction, collection);
+        }});
+      }
     }
     else {
       collection.comparator = comparator;

--- a/test/body.js
+++ b/test/body.js
@@ -350,6 +350,50 @@ describe("A Body", function () {
 
     $.ajax = oldAjax;
   });
+  
+  it("sorting on a server-mode Backbone.PageableCollection clears other sort columns", function () {
+
+    var oldAjax = $.ajax;
+    $.ajax = function (settings) {
+      settings.success([{"total_entries": 3}, [{id: 2, col2: 'b'}, {id: 1, col2: 'a'}]]);
+    };
+
+    var col = new (Backbone.PageableCollection.extend({
+      url: "test-headercell"
+    }))([{id: 1, col2: 'a'}, {id: 2, col2: 'b'}], {
+      state: {
+        pageSize: 3
+      }
+    });
+
+    grid = new Backgrid.Grid({
+      columns: [{
+        name: "id",
+        cell: "integer"
+      },{
+        name: "col2",
+        cell: "string"
+      }],
+      collection: col
+    });
+
+    grid.render();
+
+    expect(grid.collection.at(0).get("id")).toBe(1);
+    expect(grid.collection.at(1).get("id")).toBe(2);
+
+    grid.sort("id", "descending");
+    grid.sort("col2", "descending");
+
+    expect(grid.collection.at(0).get("id")).toBe(2);
+    expect(grid.collection.at(1).get("id")).toBe(1);
+    
+    // first column sort should be cleared!
+    expect(grid.columns.at(0).get("direction")).toBe(null);
+    expect(grid.columns.at(1).get("direction")).toBe("descending");
+
+    $.ajax = oldAjax;
+  });
 
   it("can sort on a client-mode Backbone.PageableCollection", function () {
 


### PR DESCRIPTION
Issue is caused by Backgrid.Body.sort handling server-side PageableCollection differently than other collections.
Call to collection.sort() cannot be performed on a server-side collection, but Backgrid.Header relies on "sort" event to trigger resetting column directions.

This fix triggers sort event on server-side PageableCollections so that proper column sort resetting behavior is maintained.

Signed-off-by: Michael Russo <merusso@gmail.com>