### PR TITLE
Column attribute support & Header row sort support

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2153,6 +2153,7 @@ var HeaderCell = Backgrid.HeaderCell = Backbone.View.extend({
     this.$el.append(label);
     this.$el.addClass(column.get("name"));
     this.$el.addClass(column.get("direction"));
+    if (column.get('attributes')) { this.$el.attr(column.get('attributes'));}
     this.delegateEvents();
     return this;
   }
@@ -2222,19 +2223,29 @@ var Header = Backgrid.Header = Backbone.View.extend({
       this.columns = new Columns(this.columns);
     }
 
-    this.row = new Backgrid.HeaderRow({
-      columns: this.columns,
-      collection: this.collection
-    });
+    var createRow = function() {
+      this.row = new Backgrid.HeaderRow({
+        columns: this.columns,
+        collection: this.collection
+      });
+    };
+    createRow.call(this);
+
+    this.listenTo(this.columns, "sort", function() {
+      createRow.call(this);
+      this.render();
+    }.bind(this));
   },
 
   /**
      Renders this table head with a single row of header cells.
    */
   render: function () {
+    this.$el.empty();
     this.$el.append(this.row.render().$el);
     this.delegateEvents();
-    return this;
+    // Trigger event
+    this.collection.trigger("backgrid:header:rendered");
   },
 
   /**


### PR DESCRIPTION
 To add support for the following extensions; Reorderable columns, Grouped columns and (re)sizeable columns I propose a few small changes to backgrid.

These are:
- 'attributes' support on column definition. Maybe we should limit this using [pick](http://underscorejs.org/#pick) to allow only valid html5 attributes. This is one way to support 'colspan' and 'rowspan' on columns.
- Header rows did not update after a sort, now they do
