### PR TITLE
`idAttribute` set to _name_ for `Backgrid.Column`

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -18,6 +18,8 @@
 */
 var Column = Backgrid.Column = Backbone.Model.extend({
 
+  idAttribute: 'name',
+
   /**
      @cfg {Object} defaults Column defaults. To override any of these default
      values, you can either change the prototype directly to override


### PR DESCRIPTION
Hi @wyuenho!
I've made a small change for easy search within the columns collection.
I think it's more convinient to use

``` javascript
backgridInstance.columns.get('file_name');
```

instead of 

``` javascript
backgridInstance.columns.findWhere({name: 'file_name'});
```
