### PR TITLE
Add default cell: "string" option for a column

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -1741,7 +1741,7 @@ var Column = Backgrid.Column = Backbone.Model.extend({
     sortType: "cycle",
     sortValue: undefined,
     direction: null,
-    cell: undefined,
+    cell: "string",
     headerCell: undefined
   },
 

--- a/src/column.js
+++ b/src/column.js
@@ -96,7 +96,7 @@ var Column = Backgrid.Column = Backbone.Model.extend({
     sortType: "cycle",
     sortValue: undefined,
     direction: null,
-    cell: undefined,
+    cell: "string",
     headerCell: undefined
   },
 


### PR DESCRIPTION
Since "string" is the most common cell type used, I see useful having it set as a default option instead of undefined - that will throw an error if not specified, of course.
