### PR TITLE
Allow HTML in empty row

### DIFF
--- a/src/row.js
+++ b/src/row.js
@@ -149,7 +149,9 @@ var EmptyRow = Backgrid.EmptyRow = Backbone.View.extend({
 
     var td = document.createElement("td");
     td.setAttribute("colspan", this.columns.length);
-    td.appendChild(document.createTextNode(_.result(this, "emptyText")));
+    var span = document.createElement("span");
+    span.innerHTML = _.result(this, "emptyText");
+    td.appendChild(span);
 
     this.el.className = "empty";
     this.el.appendChild(td);


### PR DESCRIPTION
I needed to show a CSS spinner in the empty row while the collection was fetching data.