### PR TITLE
Ignoring api directory in bower file.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "api"
   ],
   "dependencies": {
     "underscore": "~1.5.2",


### PR DESCRIPTION
The main motivation is the file api/resources/css/app-[*].css references the file ../images/facebook-16.png which doesn't exist; this causes css optimisers to fail.

When installing this project via bower, we're not necessarily interested in the api directory.