### PR TITLE
gracefully handle strings passed to the NumberFormatter

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -105,7 +105,7 @@ _.extend(NumberFormatter.prototype, {
   fromRaw: function (number, model) {
     if (_.isNull(number) || _.isUndefined(number)) return '';
 
-    number = number.toFixed(~~this.decimals);
+    number = parseFloat(number).toFixed(~~this.decimals);
 
     var parts = number.split('.');
     var integerPart = parts[0];


### PR DESCRIPTION
I was getting `undefined is not a function` errors due to my model number attr being represented as a string. e.g. 

```javascript
model.get('count') //-> "33"
```

A simple fix would just be to parseFloat the passed 'number' to ensure that it is a number.

I don't see any issue with this change ...