### PR TITLE
issue 561 fixed, can now extend Body with row option

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2,7 +2,7 @@
   backgrid 0.3.5
   http://github.com/wyuenho/backgrid
 
-  Copyright (c) 2014 Jimmy Yuen Ho Wong and contributors <wyuenho@gmail.com>
+  Copyright (c) 2015 Jimmy Yuen Ho Wong and contributors <wyuenho@gmail.com>
   Licensed under the MIT license.
 */
 
@@ -2290,7 +2290,7 @@ var Body = Backgrid.Body = Backbone.View.extend({
       this.columns = new Columns(this.columns);
     }
 
-    this.row = options.row || Row;
+    this.row = options.row || this.row || Row;
     this.rows = this.collection.map(function (model) {
       var row = new this.row({
         columns: this.columns,

--- a/src/body.js
+++ b/src/body.js
@@ -39,7 +39,7 @@ var Body = Backgrid.Body = Backbone.View.extend({
       this.columns = new Columns(this.columns);
     }
 
-    this.row = options.row || Row;
+    this.row = options.row || this.row || Row;
     this.rows = this.collection.map(function (model) {
       var row = new this.row({
         columns: this.columns,


### PR DESCRIPTION
This is the fix to issue 561, where you can't extend the Body with a custom row and have it stick.  Now you can extend the Body passing it a row, pass it to an extended Grid, and that new grid extension will have this custom row.