### PR TITLE
Populating Backbone.$ with jquery for CommonJS requires

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,7 @@ module.exports = function (grunt) {
             '    });\n' +
             '  } else if (typeof exports === "object") {\n' +
             '    // CommonJS\n' +
+            '    var Backbone = require("backbone");\n' +
             '    Backbone.$ = Backbone.$ || require("jquery");\n' +
             '    module.exports = factory(require("underscore"), Backbone);\n' +
             '  } else {\n' +

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,8 @@ module.exports = function (grunt) {
             '    });\n' +
             '  } else if (typeof exports === "object") {\n' +
             '    // CommonJS\n' +
-            '    module.exports = factory(require("underscore"), require("backbone"));\n' +
+            '    Backbone.$ = Backbone.$ || require("jquery");\n' +
+            '    module.exports = factory(require("underscore"), Backbone);\n' +
             '  } else {\n' +
             '    // Browser\n' +
             '    root.Backgrid = factory(root._, root.Backbone);\n' +

--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2,7 +2,7 @@
   backgrid 0.3.5
   http://github.com/wyuenho/backgrid
 
-  Copyright (c) 2014 Jimmy Yuen Ho Wong and contributors <wyuenho@gmail.com>
+  Copyright (c) 2015 Jimmy Yuen Ho Wong and contributors <wyuenho@gmail.com>
   Licensed under the MIT license.
 */
 
@@ -15,7 +15,8 @@
     });
   } else if (typeof exports === "object") {
     // CommonJS
-    module.exports = factory(require("underscore"), require("backbone"));
+    Backbone.$ = Backbone.$ || require("jquery");
+    module.exports = factory(require("underscore"), Backbone);
   } else {
     // Browser
     root.Backgrid = factory(root._, root.Backbone);

--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -15,6 +15,7 @@
     });
   } else if (typeof exports === "object") {
     // CommonJS
+    var Backbone = require("backbone");
     Backbone.$ = Backbone.$ || require("jquery");
     module.exports = factory(require("underscore"), Backbone);
   } else {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,10 @@
   "engines": {
     "node": ">=0.10"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "backbone": "^1.1.2",
+    "jquery": "^2.1.4",
+    "underscore": "^1.8.3"
+  }
 }


### PR DESCRIPTION
When performing a require("Backgrid"), we populate Backbone.$ with a require("jquery") statement. This is similar to other's which use Backbone in client-side environment (see: http://learnjs.io/blog/2013/11/23/backbone-jquery-browserify/).

This change technically requires the latest version of the Backgrid source to be checked in which it appears it is not. Package.json needs reference to jquery, backbone and underscore and the project output needs to be re-built.