### PR TITLE
add jQuery as a dependency for non-bower environments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,17 +45,17 @@ module.exports = function (grunt) {
             '(function (root, factory) {\n\n' +
             '  if (typeof define === "function" && define.amd) {\n' +
             '    // AMD (+ global for extensions)\n' +
-            '    define(["underscore", "backbone"], function (_, Backbone) {\n' +
-            '      return (root.Backgrid = factory(_, Backbone));\n' +
+            '    define(["underscore", "backbone", "jquery"], function (_, Backbone, jQuery) {\n' +
+            '      return (root.Backgrid = factory(_, Backbone, jQuery));\n' +
             '    });\n' +
             '  } else if (typeof exports === "object") {\n' +
             '    // CommonJS\n' +
-            '    module.exports = factory(require("underscore"), require("backbone"));\n' +
+            '    module.exports = factory(require("underscore"), require("backbone"), require("jquery"));\n' +
             '  } else {\n' +
             '    // Browser\n' +
-            '    root.Backgrid = factory(root._, root.Backbone);\n' +
+            '    root.Backgrid = factory(root._, root.Backbone, root.jQuery);\n' +
             '  }' +
-            '}(this, function (_, Backbone) {\n\n  "use strict";\n\n',
+            '}(this, function (_, Backbone, jQuery) {\n\n  "use strict";\n\n',
           footer: '  return Backgrid;\n' +
             '}));'
         },

--- a/component.json
+++ b/component.json
@@ -20,7 +20,8 @@
   ],
   "dependencies": {
     "jashkenas/underscore": "*",
-    "jashkenas/backbone": "*"
+    "jashkenas/backbone": "*",
+    "components/jquery": "*"
   },
   "demo": "http://backgridjs.com",
   "license": "MIT"

--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -10,16 +10,16 @@
 
   if (typeof define === "function" && define.amd) {
     // AMD (+ global for extensions)
-    define(["underscore", "backbone"], function (_, Backbone) {
-      return (root.Backgrid = factory(_, Backbone));
+    define(["underscore", "backbone", "jquery"], function (_, Backbone, jQuery) {
+      return (root.Backgrid = factory(_, Backbone, jQuery));
     });
   } else if (typeof exports === "object") {
     // CommonJS
-    module.exports = factory(require("underscore"), require("backbone"));
+    module.exports = factory(require("underscore"), require("backbone"), require("jquery"));
   } else {
     // Browser
-    root.Backgrid = factory(root._, root.Backbone);
-  }}(this, function (_, Backbone) {
+    root.Backgrid = factory(root._, root.Backbone, root.jQuery);
+  }}(this, function (_, Backbone, jQuery) {
 
   "use strict";
 
@@ -64,7 +64,7 @@ function lpad(str, length, padstr) {
   return padding + str;
 }
 
-var $ = Backbone.$;
+var $ = Backbone.$ = jQuery;
 
 var Backgrid = {
 

--- a/package.json
+++ b/package.json
@@ -33,5 +33,10 @@
   "engines": {
     "node": ">=0.10"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "backbone": "^1.2.1",
+    "jquery": "^2.1.4",
+    "underscore": "^1.8.3"
+  }
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -39,7 +39,7 @@ function lpad(str, length, padstr) {
   return padding + str;
 }
 
-var $ = Backbone.$;
+var $ = Backbone.$ = jQuery;
 
 var Backgrid = {
 


### PR DESCRIPTION
This PR adds jQuery as a dependency when installing via npm and component - it also defines the dependencies in package.json so they can be resolved.

As a side note, I noticed that package.json also defines `"private": true`, which may not be necessary now that backgrid is published on npm, but did not make that change in this PR.

This change also resolves #503, which was the original reason for this fix (I'm using backgrid in a browserified app).