### PR TITLE
Update dependencies to match documentation.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,8 @@
     "tests"
   ],
   "dependencies": {
-    "underscore": "~1.5.2",
-    "backbone": "~1.1.0",
-    "jquery": ">=1.10.2"
+    "backbone": ">= 1.1.0",
+    "jquery": ">= 1.7.0",
+    "underscore": "^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "private": true,
   "dependencies": {
-    "backbone": "^1.1.2",
-    "jquery": "^2.1.4",
-    "underscore": "^1.8.3"
+    "backbone": ">= 1.1.0",
+    "jquery": ">= 1.7.0",
+    "underscore": "^1.5.0"
   }
 }


### PR DESCRIPTION
They're also now more flexible.

This is as an alternative to #597 which makes the dependencies match the docs.

(We moved from using Bower for Backgrid to using NPM because of the `~1.1.0` on Backbone preventing us from using 1.2.x -- hence, I'm a believer in having more flexible version restrictions - but understand if others believe otherwise :-) )