### PR TITLE
Add dynamic colspan updating to emptyRow

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -59,6 +59,7 @@ var Body = Backgrid.Body = Backbone.View.extend({
     this.listenTo(collection, "reset", this.refresh);
     this.listenTo(collection, "backgrid:sort", this.sort);
     this.listenTo(collection, "backgrid:edited", this.moveToNextCell);
+
     this.listenTo(this.columns, "add remove", this.updateEmptyRow);
   },
 

--- a/src/body.js
+++ b/src/body.js
@@ -59,15 +59,18 @@ var Body = Backgrid.Body = Backbone.View.extend({
     this.listenTo(collection, "reset", this.refresh);
     this.listenTo(collection, "backgrid:sort", this.sort);
     this.listenTo(collection, "backgrid:edited", this.moveToNextCell);
+    this.listenTo(this.columns, "add remove", this.updateEmptyRow);
   },
 
   _unshiftEmptyRowMayBe: function () {
     if (this.rows.length === 0 && this.emptyText != null) {
-      this.rows.unshift(new EmptyRow({
+      this.emptyRow = new EmptyRow({
         emptyText: this.emptyText,
         columns: this.columns
-      }));
-      return true;
+      });
+      
+      this.rows.unshift(this.emptyRow);
+      return true
     }
   },
 
@@ -171,6 +174,17 @@ var Body = Backgrid.Body = Backbone.View.extend({
     }
 
     return this;
+  },
+
+  /**
+     Rerender the EmptyRow which empties the DOM element, creates the td with the
+     updated colspan, and appends it back into the DOM
+  */
+
+  updateEmptyRow: function () {
+    if (this.emptyRow != null) {
+      this.emptyRow.render();
+    }
   },
 
   /**

--- a/test/body.js
+++ b/test/body.js
@@ -224,6 +224,23 @@ describe("A Body", function () {
     expect(body.$el.find("tr.empty > td").attr("colspan")).toBe("1");
   });
 
+  it("will update the colspan of the empty row as columns are changed", function () {
+    col.reset();
+    body = new Backgrid.Body({
+      emptyText: " ",
+      columns: [{
+        name: "id",
+        cell: "integer"
+      }],
+      collection: col
+    });
+    body.render();
+
+    expect(body.$el.find("tr.empty > td").attr("colspan")).toBe("1");
+    body.columns.push({name: "age", cell: "integer"});
+    expect(body.$el.find("tr.empty > td").attr("colspan")).toBe("2");
+  });
+
   it("will clear the empty row if a new model is added to an empty collection", function () {
     col.reset();
     body = new Backgrid.Body({
@@ -268,6 +285,13 @@ describe("A Body", function () {
 
     body.removeRow(col.at(0));
     expect(body.$el.find("tr.empty").length).toBe(1);
+  });
+
+  it("won't call render from updateEmptyRow if there is no emptyView", function () {
+    var pushColumn = function () {
+      body.columns.push({name: "age", cell: "integer"});
+    };
+    expect(pushColumn).not.toThrow();
   });
 
   it("#sort will throw a RangeError is direction is not ascending, descending or null", function () {


### PR DESCRIPTION
Backgrid responds to changes in it's collection and columns, however it's EmptyRow isn't updated as the columns change. 

In the case where the collection is empty and the columns change - this PR enables the EmptyRow colspan to update dynamically.

This is accomplished by adding an event listener to columns, and handling the change event by calling render on the EmptyRow which is now exposed as an instance variable.

Before change:
![before fix](https://cloud.githubusercontent.com/assets/9356287/10553703/da30f0b0-7411-11e5-8dda-6b43f49f9c4e.gif)

After change:
![after fix](https://cloud.githubusercontent.com/assets/9356287/10553705/df858f9e-7411-11e5-9de2-8a9360a13391.gif)