### PR TITLE
Fix Header update problem when server-side sorted PageableCollection is updated

### DIFF
--- a/lib/backgrid.js
+++ b/lib/backgrid.js
@@ -2,7 +2,7 @@
   backgrid 0.3.5
   http://github.com/wyuenho/backgrid
 
-  Copyright (c) 2015 Jimmy Yuen Ho Wong and contributors <wyuenho@gmail.com>
+  Copyright (c) 2016 Jimmy Yuen Ho Wong and contributors <wyuenho@gmail.com>
   Licensed under the MIT license.
 */
 
@@ -1404,15 +1404,7 @@ var SelectCellEditor = Backgrid.SelectCellEditor = CellEditor.extend({
   },
 
   /** @property {function(Object, ?Object=): string} template */
-  template: _.template(
-    '<option value="<%- value %>" <%= selected ? \'selected="selected"\' : "" %>><%- text %></option>', 
-    null,
-    {
-        variable    : null,
-        evaluate    : /<%([\s\S]+?)%>/g,
-        interpolate : /<%=([\s\S]+?)%>/g,
-        escape      : /<%-([\s\S]+?)%>/g
-    }),
+  template: _.template('<option value="<%- value %>" <%= selected ? \'selected="selected"\' : "" %>><%- text %></option>', null, {variable: null}),
 
   setOptionValues: function (optionValues) {
     this.optionValues = optionValues;
@@ -2091,12 +2083,12 @@ var HeaderCell = Backgrid.HeaderCell = Backbone.View.extend({
     if (Backgrid.callByNeed(column.sortable(), column, collection)) $el.addClass("sortable");
     if (Backgrid.callByNeed(column.renderable(), column, collection)) $el.addClass("renderable");
 
-    this.listenTo(collection.fullCollection || collection, "sort", this.removeCellDirection);
+    this.listenTo(collection.fullCollection || collection, "backgrid:sorted", this.removeCellDirection);
   },
 
   /**
-     Event handler for the collection's `sort` event. Removes all the CSS
-     direction classes.
+     Event handler for the collection's `backgrid:sorted` event. Removes
+     all the CSS direction classes.
    */
   removeCellDirection: function () {
     this.$el.removeClass("ascending").removeClass("descending");
@@ -2552,18 +2544,19 @@ var Body = Backgrid.Body = Backbone.View.extend({
         }
         collection.fullCollection.sort();
         collection.trigger("backgrid:sorted", column, direction, collection);
+        column.set("direction", direction);
       }
       else collection.fetch({reset: true, success: function () {
         collection.trigger("backgrid:sorted", column, direction, collection);
+        column.set("direction", direction);
       }});
     }
     else {
       collection.comparator = comparator;
       collection.sort();
       collection.trigger("backgrid:sorted", column, direction, collection);
+      column.set("direction", direction);
     }
-
-    column.set("direction", direction);
 
     return this;
   },

--- a/src/body.js
+++ b/src/body.js
@@ -291,18 +291,19 @@ var Body = Backgrid.Body = Backbone.View.extend({
         }
         collection.fullCollection.sort();
         collection.trigger("backgrid:sorted", column, direction, collection);
+        column.set("direction", direction);
       }
       else collection.fetch({reset: true, success: function () {
         collection.trigger("backgrid:sorted", column, direction, collection);
+        column.set("direction", direction);
       }});
     }
     else {
       collection.comparator = comparator;
       collection.sort();
       collection.trigger("backgrid:sorted", column, direction, collection);
+      column.set("direction", direction);
     }
-
-    column.set("direction", direction);
 
     return this;
   },

--- a/src/header.js
+++ b/src/header.js
@@ -56,12 +56,12 @@ var HeaderCell = Backgrid.HeaderCell = Backbone.View.extend({
     if (Backgrid.callByNeed(column.sortable(), column, collection)) $el.addClass("sortable");
     if (Backgrid.callByNeed(column.renderable(), column, collection)) $el.addClass("renderable");
 
-    this.listenTo(collection.fullCollection || collection, "sort", this.removeCellDirection);
+    this.listenTo(collection.fullCollection || collection, "backgrid:sorted", this.removeCellDirection);
   },
 
   /**
-     Event handler for the collection's `sort` event. Removes all the CSS
-     direction classes.
+     Event handler for the collection's `backgrid:sorted` event. Removes
+     all the CSS direction classes.
    */
   removeCellDirection: function () {
     this.$el.removeClass("ascending").removeClass("descending");

--- a/test/header.js
+++ b/test/header.js
@@ -190,10 +190,12 @@ describe("A HeaderCell", function () {
     expect(cell.$el.hasClass("descending")).toBe(false);
   });
 
-  it("will remove its direction CSS class if `sort` is triggered from the collection or pageableCollection#fullCollection", function () {
+  it("will remove its direction CSS class if `backgrid:sorted` is triggered from the collection or pageableCollection#fullCollection", function () {
     cell.column.set("direction", "ascending");
+    expect(cell.$el.hasClass("ascending")).toBe(true);
     cell.collection.comparator = "id";
     cell.collection.sort();
+    cell.collection.trigger("backgrid:sorted");
     expect(cell.$el.hasClass("ascending")).toBe(false);
     expect(cell.$el.hasClass("descending")).toBe(false);
 
@@ -210,8 +212,10 @@ describe("A HeaderCell", function () {
     });
 
     cell.column.set("direction", "ascending");
+    expect(cell.$el.hasClass("ascending")).toBe(true);
     cell.collection.fullCollection.comparator = "id";
     cell.collection.fullCollection.sort();
+    cell.collection.fullCollection.trigger("backgrid:sorted");
     expect(cell.$el.hasClass("ascending")).toBe(false);
     expect(cell.$el.hasClass("descending")).toBe(false);
   });


### PR DESCRIPTION
1. create a server-side PageableCollection with two properties: A and B.
2. render the collection with backgrid
3. click on the 'A' header to sort by column 'A'
4. click on the 'B' header to sort by column 'B'
5. notice that the 'ascending' class on the A header is not removed, so the headers for 'A' and 'B' both render sorting arrows.

The problem is that when you 'sort' a server-side collection you aren't really triggering a 'sort' event - you're just updating the contents of the collection and the 'sort' event is never fired to erase the old 'ascending' and 'descending' classes in all the Header views.

My fix is to trigger the erasure of the 'ascending' and 'descending' classes from a 'backgrid:sorted' event, rather than a 'sort' event. There is also a small change to make sure that the Column object's 'direction' property is only changed _after_ the return of the .fetch() call on a server-side collection.
