### PR TITLE
Header cell font should not change when sortable=false

### DIFF
--- a/src/backgrid.css
+++ b/src/backgrid.css
@@ -67,6 +67,8 @@
   border: none;
   background: none;
   padding: 0;
+  font-size: inherit;
+  font-weight: inherit;
 }
 
 .backgrid.backgrid-striped tbody tr:nth-child(even) {


### PR DESCRIPTION
A button element, that is created when a cell is sortable, may have other styling than a th in browsers user stylesheet.